### PR TITLE
[HERMES-2304] Update command -> exec rename

### DIFF
--- a/slack.json
+++ b/slack.json
@@ -1,11 +1,11 @@
 {
   "manifest": {
-    "command": {
+    "exec": {
       "default": "deno run -q --unstable --allow-read https://deno.land/x/deno_slack_builder@0.0.5/mod.ts --manifest"
     }
   },
   "package": {
-    "command": {
+    "exec": {
       "default": "deno run -q --unstable --allow-read --allow-write https://deno.land/x/deno_slack_builder@0.0.5/mod.ts"
     }
   }


### PR DESCRIPTION
Updates `command` key to `exec` to reflect renaming decision. Referring to commands is relevant at the CLI level, not at the hook level.