### PR TITLE
[HERMES-2304] Update slack.json from 'exec' to 'script'

### DIFF
--- a/.slack/slack.json
+++ b/.slack/slack.json
@@ -1,11 +1,11 @@
 {
   "manifest": {
-    "exec": {
+    "script": {
       "default": "deno run -q --unstable --allow-read https://deno.land/x/deno_slack_builder@0.0.5/mod.ts --manifest"
     }
   },
   "package": {
-    "exec": {
+    "script": {
       "default": "deno run -q --unstable --allow-read --allow-write https://deno.land/x/deno_slack_builder@0.0.5/mod.ts"
     }
   }


### PR DESCRIPTION
### Summary

This pull request updates the `.slack/slack.json` keys from `exec` to `script`.

This is based on a discussion around:
* How `exec` is an overloaded term used by Golang, Cobra, and the terminal
* Script is more aligned with both Node.js (`package.json`) and Deno ([the new `deno.js` and `deno script` command](https://github.com/denoland/deno/pull/13725) h/t @curtisallen)