### PR TITLE
Adding local run support to new-project-structure branch

### DIFF
--- a/.slack/slack.json
+++ b/.slack/slack.json
@@ -8,5 +8,10 @@
     "script": {
       "default": "deno run -q --unstable --allow-read --allow-write https://deno.land/x/deno_slack_builder@0.0.5/mod.ts"
     }
+  },
+  "run": {
+    "script": {
+      "default": "deno run -q --unstable --allow-write --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts"
+    }
   }
 }

--- a/.slack/slack.json
+++ b/.slack/slack.json
@@ -12,6 +12,10 @@
   "run": {
     "script": {
       "default": "deno run -q --unstable --allow-write --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts"
+    },
+    "watcher": {
+      "filter_regex": "^.*\\.js$",
+      "paths": [ "./manifest.js" ]
     }
   }
 }


### PR DESCRIPTION
This uses the new [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) project to handle the `run` hook implementation expected by the Slack CLI.

Tested this using the latest build of the Slack CLI by:

1. Creating a project: `slack create -t ./path/to/this/repo/with/this/branch/checked/out`
2. `cd friendly-camel-whatever`
3. I have a dev Slack instance up (dev1788), but it doesn't use legit SSL certificates, so I had to edit the `run` hook inside `./.slack/slack.json` to add the "ignore SSL errors" flag to `deno`, so it looked something like: `deno run -q --unstable --allow-write --allow-read --allow-net --unsafely-ignore-certificate-errors=dev1788.slack.com https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts`
4. Local run the thing (extra flags needed for dev instances): `slack run --apihost https://dev1788.slack.com --runtime deno1.19`
5. Try it out and see your functions get run locally!