### PR TITLE
[HERMES-2252] Update run script to watch for manifest file

### DIFF
--- a/.slack/slack.json
+++ b/.slack/slack.json
@@ -14,8 +14,8 @@
       "default": "deno run -q --unstable --allow-write --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts"
     },
     "watcher": {
-      "filter_regex": "^.*\\.js$",
-      "paths": [ "./manifest.js" ]
+      "filter_regex": "^manifest\\.(ts|js|json)$",
+      "paths": [ "." ]
     }
   }
 }


### PR DESCRIPTION
### Summary

This pull request brings in the changes from PR https://github.com/slackapi/deno-reverse-string/pull/16#issuecomment-1090528368 to `new-project-structure` for MPOJ apps.

It allows the CLI watcher to detect manifest file changes from `manifest.json`, `manifest.js`, and `manifest.ts`. I don't restrict the `new-project-structure` to only `manifest.js` because the builder supports all 3 file types to become a MPOJ app.

### Test steps

```bash
# Create the project
hermes create -t slackapi/deno-reverse-string -b new-project-structure-watch-files
cd my-project/

# Start a local server
hermes run --slackdev

# Test the function

# Edit manifest.js to rename the function's title

# Confirm the function name changes in Slack
```