### PR TITLE
Add Slack API Client to imports

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.1/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.1/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.2/"
   }
 }


### PR DESCRIPTION
# Summary

Add the Slack API to our import map so that it's automatically cached when a dev uses the CLI to create a new app.

### Disclaimer
There is currently a bug in `deno-slack-builder` that prevents a user from using import maps in our function runtime files. Something like `import { SlackAPI } from "deno-slack-api/mod.ts"` doesn't work because the builder doesn't recognize the import map being passed in via script. That means developers will still need to do `import { SlackAPI } from "https://deno.land/x/deno_slack_api@0.0.2/mod.ts"`, which I expect to be confusing, but at least it's pre-cached.

This bug is fixed with https://github.com/slackapi/deno-slack-builder/pull/12