### PR TITLE
Use next version of the SDK

### DIFF
--- a/functions/reverse.ts
+++ b/functions/reverse.ts
@@ -1,4 +1,7 @@
-const reverse = async ({ inputs, env }: any) => {
+import type { FunctionHandler } from "deno-slack-sdk/types.ts";
+
+// deno-lint-ignore no-explicit-any
+const reverse: FunctionHandler<any, any> = async ({ inputs, env }) => {
   console.log(`reversing ${inputs.stringToReverse}.`);
   console.log(`SLACK_API_URL=${env["SLACK_API_URL"]}`);
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.1/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.2/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.2/"
   }
 }

--- a/manifest.ts
+++ b/manifest.ts
@@ -28,11 +28,6 @@ const ReverseFunction = DefineFunction({
 export default Manifest({
   name: "reverse",
   description: "Reverse a string",
-  // Once Manifest APIs support this, we'll add it
-  // "runtime_environment": "slack",
-  runtime: "deno1.x",
-  // The CLI should still read this and update the icon, then remove if from what's sent to manifest APIs
-  // We could have the deno-slack-builder make sure this file is included in the `output` path if helpful
   icon: "assets/icon.png",
   functions: [ReverseFunction],
   outgoingDomains: [],


### PR DESCRIPTION
# Summary

We're going to need to update the version of the SDK that we use for re-ignite, and it will require some updates to our files as well

1. Make use the `FunctionHandler` type in our function definition files
2. Remove `runtime` from manifest
3. Bump version of the SDK