### PR TITLE
Move the required field beneath properties

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -6,22 +6,22 @@ const ReverseFunction = DefineFunction({
   description: "Takes a string and reverses it",
   source_file: "functions/reverse.ts",
   input_parameters: {
-    required: ["stringToReverse"],
     properties: {
       stringToReverse: {
         type: Schema.types.string,
         description: "The string to reverse",
       },
     },
+    required: ["stringToReverse"],
   },
   output_parameters: {
-    required: ["reverseString"],
     properties: {
       reverseString: {
         type: Schema.types.string,
         description: "The string in reverse",
       },
     },
+    required: ["reverseString"],
   },
 });
 


### PR DESCRIPTION
### Summary
Moving the required field beneath the properties

### Details
There was confusion about a TS error around a required field that wasn't actually a parameter yet. We haven't figured out the right way to give specific error messaging for this kind of situation with our types, but it makes more sense to define the properties that are available before we say which are required.

Convo: https://slack-pde.slack.com/archives/C03BS52QLPJ/p1649958372816539