### PR TITLE
Reignite Release

### DIFF
--- a/functions/reverse_test.ts
+++ b/functions/reverse_test.ts
@@ -1,8 +1,11 @@
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import ReverseString from "./reverse.ts";
 
+const { createContext } = SlackFunctionTester("reverse");
+
 Deno.test("Reverse string function test", async () => {
   const inputs = { stringToReverse: "foo" };
-  const { outputs } = await ReverseString({ inputs, env: {} });
+  const { outputs } = await ReverseString(createContext({ inputs }));
   assertEquals(outputs?.reverseString, "oof");
 });

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.2/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.3/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.2/"
   }
 }

--- a/manifest.ts
+++ b/manifest.ts
@@ -6,22 +6,22 @@ const ReverseFunction = DefineFunction({
   description: "Takes a string and reverses it",
   source_file: "functions/reverse.ts",
   input_parameters: {
-    required: ["stringToReverse"],
     properties: {
       stringToReverse: {
         type: Schema.types.string,
         description: "The string to reverse",
       },
     },
+    required: ["stringToReverse"],
   },
   output_parameters: {
-    required: ["reverseString"],
     properties: {
       reverseString: {
         type: Schema.types.string,
         description: "The string in reverse",
       },
     },
+    required: ["reverseString"],
   },
 });
 

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.4/mod.ts"
+    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.5/mod.ts"
   }
 }


### PR DESCRIPTION
- Bump SDK to `0.0.3`
- Bump Hooks lib to `0.0.5`
- Use the new `SlackFunctionTester` for function context so tests pass again
- Move the `required` field beneath `properties`
    - I think this is on `new-project-with-sdk` already, this commit just has a different hash