### PR TITLE
Use new SlackFunctionHandler type and update SDK, API, Builder

### DIFF
--- a/functions/reverse.ts
+++ b/functions/reverse.ts
@@ -1,7 +1,9 @@
-import type { FunctionHandler } from "deno-slack-sdk/types.ts";
+import type { SlackFunctionHandler } from "deno-slack-sdk/types.ts";
+import type { ReverseFunction } from "../manifest.ts";
 
-// deno-lint-ignore no-explicit-any
-const reverse: FunctionHandler<any, any> = async ({ inputs, env }) => {
+const reverse: SlackFunctionHandler<typeof ReverseFunction.definition> = async (
+  { inputs, env },
+) => {
   console.log(`reversing ${inputs.stringToReverse}.`);
   console.log(`SLACK_API_URL=${env["SLACK_API_URL"]}`);
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.3/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.2/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.4/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
   }
 }

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,6 +1,6 @@
 import { DefineFunction, Manifest, Schema } from "deno-slack-sdk/mod.ts";
 
-const ReverseFunction = DefineFunction({
+export const ReverseFunction = DefineFunction({
   callback_id: "reverse",
   title: "Reverse",
   description: "Takes a string and reverses it",

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.5/mod.ts"
+    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.6/mod.ts"
   }
 }


### PR DESCRIPTION
# Summary
Use our new `SlackFunctionHandler` type and update versions of the SDK, API, and Builder