### PR TITLE
Updating hooks to 0.0.7

### DIFF
--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.6/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.7/mod.ts"
   }
 }


### PR DESCRIPTION
## Summary

This updates to the latest hooks version, which replaces Deno.emit() usage in the builder for deno v1.22.0 support.