### PR TITLE
Cheng release - Update import_map.json

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.4/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.4/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
   }
 }


### PR DESCRIPTION
Updated import_map.json to reference to latest SDK and API version for June 10, 2022 release