### PR TITLE
Cheng release - Update slack.json to reference latest hook version

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.4/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.4/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
   }
 }

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.8/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.10/mod.ts"
   }
 }


### PR DESCRIPTION
Update slack.json to reference latest hook version for release (June 10th, 2022)