### PR TITLE
Remove deno unstable flag from vscode settings 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true,
   "deno.suggest.imports.hosts": {
     "https://deno.land": false
   },


### PR DESCRIPTION
Removes deno unstable flag from vscode settings a la [this thread](https://slack-pde.slack.com/archives/C02HWTPG26T/p1656440951677649).

We've removed the usage of `unstable` from the deno SDK and CLI, makes sense to remove it here too.

Examples of other removals:
https://github.com/slackapi/deno-slack-builder/pull/22
https://github.com/slackapi/deno-slack-runtime/pull/17
https://github.com/slackapi/deno-slack-api/pull/16
https://github.com/slackapi/deno-slack-hooks/pull/20