### PR TITLE
Add a trigger.ts file with instructions on how to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ slack run
 slack deploy
 ```
 
+## Seeing it in action
+After creating your app, you'll need to create a new trigger that will start the workflow.
+
+```bash
+slack triggers create --trigger-def ./trigger.ts
+```
+
 ## Testing
 
 You can write tests for your function, see `functions/reverse_test.ts` for a

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.7/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.7/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.8/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.8/"
   }
 }

--- a/trigger.ts
+++ b/trigger.ts
@@ -1,0 +1,10 @@
+import { ValidTriggerTypes } from "deno-slack-api/types.ts";
+
+const trigger: ValidTriggerTypes = {
+  type: "shortcut",
+  name: "Reverse a String",
+  description: "Starts the workflow to test reversing a string",
+  workflow: "#/workflows/test_reverse",
+};
+
+export default trigger;


### PR DESCRIPTION
### Summary

Adding a `trigger.ts` file that can be used as the `trigger_def` passed to the CLI. This only works in the version of the CLI that is currently being released.