### PR TITLE
Added GitHub action to trigger e2e_test remotely #11

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Capture triggering branch name
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Trigger CircleCI build-beta workflow.
         uses: promiseofcake/circleci-trigger-action@v1
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,20 @@
+name: Execute End-to-end with CircleCI
+
+on:
+  # push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Capture triggering branch name
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: Trigger CircleCI build-beta workflow.
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLECI_TOKEN }}
+          project-slug: slackapi/slack-cli
+          branch: main
+          payload: '{"run_local_build_test_workflow": true, "deno_reverse_string_template_branch": "${{env.BRANCH_NAME}}"}'


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [x] Automation pipeline

### Summary

Newly added GitHub action which will help trigger `Slack-CLI` build&e2e_test pipeline via this action remotely. 
When a new PR is opened, the e2e test will be triggered remotely.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
